### PR TITLE
Add a console warning when using a key which returns null for geolocation data

### DIFF
--- a/geoLocationCloud.js
+++ b/geoLocationCloud.js
@@ -56,6 +56,11 @@ class GeoLocationCloud extends Engine {
 
       cloudData = JSON.parse(cloudData);
 
+      if (cloudData.device && cloudData.device.geolocation === null && cloudData.device.geolocationnullreason) {
+        console.warn("WARNING: geolocation not populated. " + cloudData.device.geolocationnullreason + "\n" +
+          "This may be because the provided API key is not authorised for geolocation queries.")
+      }
+
       // Loop over cloudData.location or cloudData.location_digitalelement properties to check if they have a value
 
       const result = {};


### PR DESCRIPTION
If an API key is used which is not authorised for geolocation data then the API will return device.geolocation null (see issue #2).
Detect this situation and print a console warning to at least alert the user that they may be using the wrong key.

Note: there may be a better way to accurately detect this situation.
The warning message might also explain how to rectify this situation, or check that it is the case; I am not expecting this PR to necessarily be merged directly! It would be useful to be able to show the permissions on an API key, and if that becomes possible then the message should indicate that the developer should do that to see what the key in question is permitted to do.